### PR TITLE
Fix: Correct JSON-LD syntax in schema_json.html

### DIFF
--- a/layouts/partials/templates/schema_json.html
+++ b/layouts/partials/templates/schema_json.html
@@ -1,0 +1,130 @@
+{{ if .IsHome }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "{{- ( site.Params.schema.publisherType | default "Organization") | title -}}",
+  "name": {{ site.Title | printf "%q" }},
+  "url": {{ site.Home.Permalink | printf "%q" }},
+  "description": {{ site.Params.description | plainify | truncate 180 | safeHTML | printf "%q" }},
+  {{- if (eq site.Params.schema.publisherType "Person") }}
+  "image": {{ site.Params.assets.favicon | default "favicon.ico" | absURL | printf "%q" }},
+  {{- else }}
+  "logo": {{ site.Params.assets.favicon | default "favicon.ico" | absURL | printf "%q" }},
+  {{- end }}
+  "sameAs": [
+    {{- if site.Params.schema.sameAs }}
+      {{ range $i, $e := site.Params.schema.sameAs }}{{ if $i }}, {{ end }}{{ trim $e " " | printf "%q" }}{{ end }}
+    {{- else}}
+      {{ range $i, $e := site.Params.SocialIcons }}{{ if $i }}, {{ end }}{{ trim $e.url " " | safeURL | printf "%q" }}{{ end }}
+    {{- end}}
+  ]
+}
+</script>
+{{- else if (or .IsPage .IsSection) }}
+{{/* BreadcrumbList */}}
+{{- $url := replace .Parent.Permalink ( printf "%s" site.Home.Permalink) "" }}
+{{- $lang_url := strings.TrimPrefix ( printf "%s/" .Lang) $url }}
+{{- $bc_list := (split $lang_url "/")}}
+
+{{- $scratch := newScratch }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+  {{- range $index, $element := $bc_list }}
+
+    {{- $scratch.Add "path" (printf "%s/" $element ) | safeJS }}
+    {{- $bc_pg := site.GetPage ($scratch.Get "path") -}}
+
+    {{- if (and ($bc_pg) (gt (len . ) 0))}}
+    {{- if (and $index)}}, {{end }}
+    {
+      "@type": "ListItem",
+      "position": {{ add 1 $index  }},
+      "name": {{ $bc_pg.Name | printf "%q" }},
+      "item": {{ $bc_pg.Permalink | safeHTML | printf "%q" }}
+    }
+    {{- end }}
+
+  {{- end }}
+  {{- /*  self-page addition  */ -}}
+  {{- if gt (len $bc_list) 0 }}{{/* Ensure $bc_list is not empty before adding comma for self-page */}}
+    {{- if ne (len $bc_list) 1 }}, {{end}}
+  {{- else if .IsPage}}, {{end}}
+    {
+      "@type": "ListItem",
+      "position": {{ if gt (len $bc_list) 0 }}{{ len $bc_list }}{{ else }}1{{ end }},
+      "name": {{ .Name | printf "%q" }},
+      "item": {{ .Permalink | safeHTML | printf "%q" }}
+    }
+  ]
+}
+</script>
+{{- if .IsPage }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": {{ .Title | plainify | printf "%q" }},
+  "name": "{{ .Title | plainify }}",
+  "description": {{ with .Description | plainify }}{{ . | printf "%q" }}{{ else }}{{ .Summary | plainify | printf "%q" }}{{ end -}},
+  "keywords": [
+    {{- if .Params.keywords }}
+    {{ range $i, $e := .Params.keywords }}{{ if $i }}, {{ end }}{{ $e | printf "%q" }}{{ end }}
+    {{- else }}
+    {{ range $i, $e := .Params.tags }}{{ if $i }}, {{ end }}{{ $e | printf "%q" }}{{ end }}
+    {{- end }}
+  ],
+  "articleBody": {{ .Content | safeJS | htmlUnescape | plainify | printf "%q" }},
+  "wordCount" : "{{ .WordCount }}",
+  "inLanguage": {{ .Language.Lang | default "en-us" | printf "%q" }},
+  {{ if .Params.cover.image -}}
+  "image":
+    {{- if (ne .Params.cover.relative true) -}}
+    {{ .Params.cover.image | absURL | printf "%q" }},
+    {{- else -}}
+    {{ (path.Join .RelPermalink .Params.cover.image ) | absURL | printf "%q" }},
+    {{- end}}
+  {{- else }}
+    {{- $images := partial "templates/_funcs/get-page-images" . -}}
+    {{- with index $images 0 -}}
+  "image": {{ .Permalink | printf "%q" }},
+    {{- end }}
+  {{- end -}}
+  "datePublished": {{ .PublishDate.Format "2006-01-02T15:04:05Z07:00" | printf "%q" }},
+  "dateModified": {{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" | printf "%q" }},
+  {{- with (.Params.author | default site.Params.author) }}
+  "author":
+    {{- if (or (eq (printf "%T" .) "[]string") (eq (printf "%T" .) "[]interface {}")) -}}
+  [{{- range $i, $v := . -}}
+  {{- if $i }}, {{end -}}
+  {
+    "@type": "Person",
+    "name": {{ $v | printf "%q" }}
+  }
+  {{- end }}],
+    {{- else -}}
+  {
+    "@type": "Person",
+    "name": {{ . | printf "%q" }}
+  },
+    {{- end -}}
+  {{- end }}
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": {{ .Permalink | safeHTML | printf "%q" }}
+  },
+  "publisher": {
+    "@type": "{{- ( site.Params.schema.publisherType | default "Organization") | title -}}",
+    "name": {{ site.Title | printf "%q" }},
+    "logo": {
+      "@type": "ImageObject",
+      "url": {{ site.Params.assets.favicon | default "favicon.ico" | absURL | printf "%q" }}
+    }
+  }
+}
+</script>
+{{- end }}{{/* .IsPage end */}}
+
+{{- end -}}


### PR DESCRIPTION
The Hugo build was failing due to a JSON syntax error, specifically "expected comma character or an array or object ending". I traced this to the `schema_json.html` partial in the PaperMod theme.

The partial was generating invalid JSON-LD because various string values (titles, descriptions, keywords/tags, URLs, dates, author names, etc.) were not being enclosed in double quotes.

This commit introduces an override file at
`layouts/partials/templates/schema_json.html` which contains the corrected logic. It uses Hugo's `printf "%q"` function to ensure all string literals are properly quoted and formats dates to ISO 8601 standard for JSON-LD.

This change should resolve the build error and ensure valid structured data is generated for SEO purposes.